### PR TITLE
Updated references to ModTools

### DIFF
--- a/docs/source/modding/Workflow/Reverse-Engineering.rst
+++ b/docs/source/modding/Workflow/Reverse-Engineering.rst
@@ -39,12 +39,17 @@ Remember that you can **search**!
 
 Using the ModTools mod
 ----------------------
-Thanks to `nlight <http://www.skylinesmodding.com/users/nlight/>`__ we now have a mod that can help with reverse engineering.
+Thanks to nlight we now have a mod that can help with reverse engineering.
 This mod has a scene explorer which allows you to examine all objects in the scene.
 It doesn't just list the objects it also shows all the components, fields, properties and methods.
 This will help you a lot with understanding how the game works and find the parts of the code you need.
 It also has some other useful features like logging exceptions in the console so make sure to check it out!
-`ModTools by nlight. <http://www.skylinesmodding.com/t/modtools-in-game-debugging/123>`__
+
+Unfortunately the mod is no longer maintained, but you can use the fixed version by BloodyPenguin which is compatible with CS1.1+.  
+
+* `Steam Workshop <https://steamcommunity.com/sharedfiles/filedetails/?id=450877484>`_  
+* `Github Repository <https://github.com/earalov/Skylines-ModTools>`_  
+
 
 More things to reverse engineer
 -------------------------------


### PR DESCRIPTION
- removed links to skylinesmodding.com since the domain is inactive (that is, it's currently serving scam/phishing content)  
- added reference to BloodyPenguin's updated Modtools  
- added links to Steam Workshop page and GitHub page